### PR TITLE
Amend tests, fix crossroads throne room

### DIFF
--- a/logHandler.py
+++ b/logHandler.py
@@ -2,7 +2,7 @@ import os
 
 class LogHandler():
 	LOGS_DIR = "logs"
-	CSS_LINK = "<link rel=\"stylesheet\" href=\"../static/css/bootstrap.min.css\"/>"
+	CSS_LINK = "<link rel=\"stylesheet\" href=\"../static/style.css\"/>"
 
 	def __init__(self, file_title):
 		self.file_title = file_title

--- a/net.py
+++ b/net.py
@@ -212,7 +212,9 @@ class DmHandler(GameHandler):
 
 		if abandoned:
 			self.application.games.remove(self.client.game)
-			self.client.game = None
+			for i in self.client.game.players:
+				i.game = None
+				i.waiter.remove_timer()
 		else:
 			if self.client.last_mode["mode"] == "gameover":
 				#remove me from the game

--- a/sets/base.py
+++ b/sets/base.py
@@ -209,8 +209,8 @@ class Feast(crd.Card):
 	@gen.coroutine
 	def play(self, skip=False):
 		crd.Card.play(self, skip)
-		if self.played_by.played[-1] == self:
-			self.game.trash_pile.append(self.played_by.played.pop())
+		if self.played_by.played_cards[-1] == self:
+			self.game.trash_pile.append(self.played_by.played_cards.pop())
 			self.game.update_trash_pile()
 			self.game.announce("-- trashing " + self.log_string())
 		self.played_by.update_resources()
@@ -475,7 +475,7 @@ class Throne_Room(crd.Card):
 				card.played_by.update_resources()
 
 			selected_card.done = second_play
-			self.played_by.discard(selection, self.played_by.played)
+			self.played_by.discard(selection, self.played_by.played_cards)
 			self.game.announce(throne_room_str)
 			selected_card.play(True)
 			self.played_by.update_resources()

--- a/sets/base.py
+++ b/sets/base.py
@@ -458,6 +458,7 @@ class Throne_Room(crd.Card):
 		if not selection:
 			self.done = lambda : None
 			self.game.announce(" -- but has no action cards")
+			crd.Card.on_finished(self, False, False)
 		else:
 			selected_card = self.played_by.hand.get_card(selection[0])
 			throne_room_str = self.played_by.name_string() + " " + self.log_string(True) + " " + selected_card.log_string()

--- a/sets/card.py
+++ b/sets/card.py
@@ -16,9 +16,9 @@ class Card():
 
 	def play(self, skip=False):
 		if "Action" in self.type:
-			self.played_by.played_actions += 1
+			self.played_by.played_inclusive.append(self)
 		if not skip:
-			self.played_by.discard([self.title], self.played_by.played)
+			self.played_by.discard([self.title], self.played_by.played_cards)
 			self.game.announce(self.played_by.name_string() + " played " + self.log_string())
 			if "Action" in self.type:
 				self.played_by.actions -= 1
@@ -74,7 +74,7 @@ class Card():
 	def on_gain_effect(self, gained_card):
 		pass
 
-	#called after card finishes resolving and is put into the played pile
+	#called after card finishes resolving and is put into the played_cards pile
 	def done(self):
 		pass
 

--- a/sets/hinterlands.py
+++ b/sets/hinterlands.py
@@ -187,6 +187,7 @@ class Mandarin(crd.Card):
 				self.played_by.announce_self("-- You place " + card_string + " back on top of your deck")
 			crd.Card.on_finished(self, True)
 
+	@gen.coroutine
 	def on_gain(self):
 		played_treasures = [x for x in self.played_by.played if "Treasure" in x.type]
 		#remove treasures from played pile
@@ -195,7 +196,7 @@ class Mandarin(crd.Card):
 			self.game.announce("-- placing treasures back on top of their deck")
 			self.played_by.deck += played_treasures
 		else:
-			crd.reorder_top(self.played_by, played_treasures, lambda :self.done_gaining())
+			yield crd.reorder_top(self.played_by, played_treasures, lambda :self.done_gaining())
 
 	def done_gaining(self):
 		self.game.announce("-- placing treasures back on top of their deck")

--- a/sets/hinterlands.py
+++ b/sets/hinterlands.py
@@ -14,9 +14,10 @@ class Crossroads(crd.Card):
 		self.type = "Action"
 
 	def play(self, skip=False):
-		cards_played = list(map(lambda x : x.title, self.played_by.played))
 		crd.Card.play(self, skip)
-		if "Crossroads" not in cards_played:
+		crossroads_played = [c for c in self.played_by.played_inclusive if c.title == "Crossroads"]
+		# if this was the only one played just noow
+		if len(crossroads_played) == 1:
 			self.played_by.actions += 3
 			self.game.announce("-- gaining 3 actions")
 		#Announce announces everything to all players in log, reveal_string adds css to cards in log 
@@ -230,9 +231,9 @@ class Mandarin(crd.Card):
 
 	@gen.coroutine
 	def on_gain(self):
-		played_treasures = [x for x in self.played_by.played if "Treasure" in x.type]
+		played_treasures = [x for x in self.played_by.played_cards if "Treasure" in x.type]
 		#remove treasures from played pile
-		self.played_by.played = [x for x in self.played_by.played if "Treasure" not in x.type]
+		self.played_by.played_cards = [x for x in self.played_by.played_cards if "Treasure" not in x.type]
 		if len(played_treasures) == 1 or len(set(map(lambda x: x.title, played_treasures))) == 1:
 			self.game.announce("-- placing treasures back on top of their deck")
 			self.played_by.deck += played_treasures

--- a/sets/intrigue.py
+++ b/sets/intrigue.py
@@ -398,7 +398,7 @@ class Conspirator(crd.Card):
 		self.played_by.balance += 2
 
 		announcement = "-- gaining $2"
-		if self.played_by.played_actions >= 3:
+		if len([x for x in self.played_by.played_inclusive if "Action" in x.type]) >= 3:
 			self.played_by.actions += 1
 			drawn = self.played_by.draw(1)
 			announcement += " and drawing " + drawn + " and gaining +1 action"
@@ -487,10 +487,10 @@ class Mining_Village(crd.Card):
 		if "Yes" in selection:
 			if len(self.game.trash_pile) > 0 and self.game.trash_pile[-1] == self:
 				self.game.announce("-- tries to trash " + self.log_string() + " but it was already trashed")
-			elif self in self.played_by.played:
+			elif self in self.played_by.played_cards:
 				self.game.announce("-- trashing " + self.log_string() + " to gain $2")
 				self.played_by.balance += 2
-				self.played_by.played.pop()
+				self.played_by.played_cards.pop()
 				self.game.trash_pile.append(self)
 				self.game.update_trash_pile()
 		crd.Card.on_finished(self)

--- a/sets/prosperity.py
+++ b/sets/prosperity.py
@@ -383,19 +383,19 @@ class Mint(crd.Card):
 	@gen.coroutine
 	def play(self, skip=False):
 		crd.Card.play(self, skip)
-		treasures = self.played_by.hand.get_cards_by_type("Treasure", True)
-		treasures = list(set(map(lambda x: x.title, treasures)))
+		treasure_cards = self.played_by.hand.get_cards_by_type("Treasure", True)
+		treasures_titles = list(set(map(lambda x: x.title, treasure_cards)))
 
 		# perhaps write an auto_select method for lists?
-		if len(treasures) == 0:
+		if len(treasures_titles) == 0:
 			self.game.announce("-- but there were no treasures to reveal")
 			crd.Card.on_finished(self, False, False)
-		elif len(treasures) == 1:
-			self.game.announce("-- revealing " + treasures[0].log_string + ", gaining a copy of it.")
-			yield self.played_by.gain(treasures[0])
+		elif len(treasures_titles) == 1:
+			self.game.announce("-- revealing " + treasure_cards[0].log_string + ", gaining a copy of it.")
+			yield self.played_by.gain(treasure_cards[0])
 			crd.Card.on_finished(self, False, False)
 		else:
-			selection = yield self.played_by.select(1, 1, treasures, "Choose a card to reveal")
+			selection = yield self.played_by.select(1, 1, treasures_titles, "Choose a card to reveal")
 			self.game.announce("-- revealing " + self.game.log_string_from_title(selection[0]) + ", gaining a copy of it.")
 			yield self.played_by.gain(selection[0])
 			crd.Card.on_finished(self, False, False)

--- a/sets/prosperity.py
+++ b/sets/prosperity.py
@@ -402,9 +402,9 @@ class Mint(crd.Card):
 
 	def on_buy(self):
 		trashed_treasures = list()
-		for i in range(len(self.played_by.played) - 1, -1, -1):
-			if self.played_by.played[i].type == 'Treasure':
-				trashed_treasures.append(self.played_by.played.pop(i))
+		for i in range(len(self.played_by.played_cards) - 1, -1, -1):
+			if self.played_by.played_cards[i].type == 'Treasure':
+				trashed_treasures.append(self.played_by.played_cards.pop(i))
 		announce_string = ", ".join(list(map(lambda x: self.game.log_string_from_title(x.title), trashed_treasures)))
 
 		self.game.announce("-- trashing " + announce_string)
@@ -598,7 +598,7 @@ class Venture(crd.Money):
 			self.game.announce("-- revealing " + card.log_string())
 			self.game.announce("-- " + self.played_by.name_string() + " played " + card.log_string())
 			card.play(True)
-			self.played_by.played.append(card)
+			self.played_by.played_cards.append(card)
 		crd.Money.on_finished(self)
 
 # --------------------------------------------------------
@@ -692,7 +692,7 @@ class Bank(crd.Money):
 	def play(self, skip=False):
 		crd.Card.play(self, skip)
 		total_played_treasures = 0
-		for card in self.played_by.played:
+		for card in self.played_by.played_cards:
 			if "Treasure" in card.type:
 				total_played_treasures += 1
 		self.played_by.balance += total_played_treasures
@@ -763,7 +763,7 @@ class Kings_Court(crd.Card):
 			#after playing the card the first time, we set the done callback to play_again and override the default
 			#done callback for the 2nd time the card is played to play_again to play a 3rd time
 			selected_card.done = lambda : play_again(done_cb=play_again)
-			self.played_by.discard(selection, self.played_by.played)
+			self.played_by.discard(selection, self.played_by.played_cards)
 			self.game.announce(kings_court_str)
 			selected_card.play(True)
 			self.played_by.update_resources()
@@ -829,5 +829,5 @@ class Peddler(crd.Card):
 
 	#called when the buy phase begins
 	def on_buy_phase(self):
-		modifier = self.game.get_turn_owner().played_actions * -2
+		modifier = len([x for x in self.game.get_turn_owner().played_inclusive if "Action" in x.type]) * -2
 		self.game.price_modifier[self.title] = modifier

--- a/sets/prosperity.py
+++ b/sets/prosperity.py
@@ -384,18 +384,18 @@ class Mint(crd.Card):
 	def play(self, skip=False):
 		crd.Card.play(self, skip)
 		treasure_cards = self.played_by.hand.get_cards_by_type("Treasure", True)
-		treasures_titles = list(set(map(lambda x: x.title, treasure_cards)))
+		treasure_titles = list(set(map(lambda x: x.title, treasure_cards)))
 
 		# perhaps write an auto_select method for lists?
-		if len(treasures_titles) == 0:
+		if len(treasure_titles) == 0:
 			self.game.announce("-- but there were no treasures to reveal")
 			crd.Card.on_finished(self, False, False)
-		elif len(treasures_titles) == 1:
-			self.game.announce("-- revealing " + treasure_cards[0].log_string + ", gaining a copy of it.")
-			yield self.played_by.gain(treasure_cards[0])
+		elif len(treasure_titles) == 1:
+			self.game.announce("-- revealing " + treasure_cards[0].log_string() + ", gaining a copy of it.")
+			yield self.played_by.gain(treasure_titles[0])
 			crd.Card.on_finished(self, False, False)
 		else:
-			selection = yield self.played_by.select(1, 1, treasures_titles, "Choose a card to reveal")
+			selection = yield self.played_by.select(1, 1, treasure_titles, "Choose a card to reveal")
 			self.game.announce("-- revealing " + self.game.log_string_from_title(selection[0]) + ", gaining a copy of it.")
 			yield self.played_by.gain(selection[0])
 			crd.Card.on_finished(self, False, False)

--- a/tests/game_tests.py
+++ b/tests/game_tests.py
@@ -85,7 +85,7 @@ class TestGame(unittest.TestCase):
 		self.player1.spend_all_money()
 		self.assertTrue(self.player1.balance == 5)
 		self.assertTrue(len(self.player1.hand) == 0)
-		self.assertTrue(len(self.player1.played) == 5)
+		self.assertTrue(len(self.player1.played_cards) == 5)
 		self.assertTrue(len([x for x in self.player1.all_cards() if x.title == "Copper"]) == 5)
 
 	def test_discard(self):

--- a/tests/hinterlands_tests.py
+++ b/tests/hinterlands_tests.py
@@ -54,6 +54,18 @@ class TestHinterland(tornado.testing.AsyncTestCase):
 		self.assertTrue(len(self.player1.hand) == expected_drawn + base_hand_size - 1) 
 
 	@tornado.testing.gen_test
+	def test_Crossroads_Throne_Room(self):
+		tu.print_test_header("test Crossroads Throne Room")
+		crossroads = hl.Crossroads(self.game, self.player1)
+		throneroom = base.Throne_Room(self.game, self.player1)
+		self.player1.hand.add(throneroom)
+		self.player1.hand.add(crossroads)
+		
+		tu.send_input(self.player1, "play", "Throne Room")
+		yield tu.send_input(self.player1, "post_selection", ["Crossroads"])
+		self.assertTrue(self.player1.actions == 3)
+
+	@tornado.testing.gen_test
 	def test_Duchess(self):
 		tu.print_test_header("Test Duchess")
 		duchess = hl.Duchess(self.game, self.player1)
@@ -167,7 +179,7 @@ class TestHinterland(tornado.testing.AsyncTestCase):
 		
 		self.assertTrue(self.player1.last_mode["mode"] == "select")
 		yield tu.send_input(self.player1, "post_selection", ["Silver", "Silver", "Gold"])
-		self.assertTrue(len(self.player1.played) == 0)
+		self.assertTrue(len(self.player1.played_cards) == 0)
 		self.assertTrue(self.player1.deck[-1].title == "Gold")
 		self.assertTrue(self.player1.deck[-2].title == "Silver")
 		self.assertTrue(self.player1.deck[-3].title == "Silver")

--- a/tests/hinterlands_tests.py
+++ b/tests/hinterlands_tests.py
@@ -145,7 +145,8 @@ class TestHinterland(tornado.testing.AsyncTestCase):
 		tu.send_input(self.player1, "play", "Silver")
 		tu.send_input(self.player1, "play", "Silver")
 
-		tu.send_input(self.player1, "buyCard", "Mandarin")
+		yield tu.send_input(self.player1, "buyCard", "Mandarin")
+		
 		self.assertTrue(self.player1.last_mode["mode"] == "select")
 		yield tu.send_input(self.player1, "post_selection", ["Silver", "Silver", "Gold"])
 		self.assertTrue(len(self.player1.played) == 0)

--- a/tests/intrigue_tests.py
+++ b/tests/intrigue_tests.py
@@ -434,7 +434,7 @@ class TestIntrigue(tornado.testing.AsyncTestCase):
 		yield tu.send_input(self.player1, "post_selection", ["Yes"])
 		self.assertTrue(self.player1.actions == 3)
 		self.assertTrue(self.game.trash_pile[-1].title == "Mining Village")
-		self.assertTrue(len(self.player1.played)==1)
+		self.assertTrue(len(self.player1.played_cards)==1)
 		self.assertTrue(self.player1.balance == 2)
 
 	@tornado.testing.gen_test
@@ -494,7 +494,7 @@ class TestIntrigue(tornado.testing.AsyncTestCase):
 		copper.play()
 		self.assertTrue(self.player1.balance == 3)
 		#we played throne room, coppersmith, copper
-		self.assertTrue(len(self.player1.played) == 3)
+		self.assertTrue(len(self.player1.played_cards) == 3)
 		self.player1.end_turn()
 		self.assertTrue(copper.value == 1)
 		#make sure we only have 1 coppersmith in our deck
@@ -682,7 +682,7 @@ class TestIntrigue(tornado.testing.AsyncTestCase):
 		village.play()
 		mv.play()
 		yield tu.send_input(self.player1, "post_selection", ["Yes"])
-		self.assertFalse(mv in self.player1.played)
+		self.assertFalse(mv in self.player1.played_cards)
 		self.assertTrue(mv in self.game.trash_pile)
 		self.assertTrue(self.player1.actions == 3)
 		conspirator.play()

--- a/tests/prosperity_tests.py
+++ b/tests/prosperity_tests.py
@@ -558,6 +558,15 @@ class TestProsperity(tornado.testing.AsyncTestCase):
 		yield tu.send_input(self.player1, "buyCard", "Copper")
 		self.assertTrue(self.game.supply.get_count("Copper") == coppers - 2)
 
+	def test_Mint_auto_select(self):
+		tu.print_test_header("test Mint auto select")
+		mint = prosperity.Mint(self.game, self.player1)
+		tu.set_player_hand(self.player1, [mint, crd.Silver(self.game, self.player1)])
+
+		mint.play()
+		self.assertTrue(self.player1.last_mode["mode"] == "buy")
+		self.assertTrue(self.player1.discard_pile[-1].title == "Silver")
+
 
 if __name__ == '__main__':
 	unittest.main()

--- a/waitHandler.py
+++ b/waitHandler.py
@@ -29,10 +29,7 @@ class WaitHandler():
 
 	def handle_reconnect(self, reconnecting_player):
 		self.waiting_on.remove(reconnecting_player.name)
-		if self.disconnect_timer:
-			ioloop.IOLoop.instance().remove_timeout(self.disconnect_timer)
-			self.disconnect_timer = None
-
+		self.remove_timer()
 
 	def set_lock(self, locked_person, locked):
 		if locked:
@@ -55,11 +52,11 @@ class WaitHandler():
 		if count == 1:
 			for i in self.player.get_opponents():
 				i.wait(": they have disconnected for {} minute".format(count), self.player)
-			self.disconnect_timer = ioloop.IOLoop.instance().call_later(60, lambda x=count: self.time_disconnect(x))
+			self.disconnect_timer = ioloop.IOLoop.instance().call_later(1, lambda x=count: self.time_disconnect(x))
 		elif count < 5:
 			for i in self.player.get_opponents():
 				i.wait(": they have disconnected for {} minutes".format(count), self.player)
-			self.disconnect_timer = ioloop.IOLoop.instance().call_later(60, lambda x=count: self.time_disconnect(x))
+			self.disconnect_timer = ioloop.IOLoop.instance().call_later(1, lambda x=count: self.time_disconnect(x))
 		else:
 			futures = []
 			for i in self.player.get_opponents():
@@ -69,3 +66,10 @@ class WaitHandler():
 				selected = yield wait_iterator.next()
 				if selected == ["Yes"]:
 					self.player.game.end_game([self.player])
+
+	def remove_timer(self):
+		if self.disconnect_timer:
+			ioloop.IOLoop.instance().remove_timeout(self.disconnect_timer)
+			self.disconnect_timer = None
+
+

--- a/waitHandler.py
+++ b/waitHandler.py
@@ -52,9 +52,13 @@ class WaitHandler():
 	@gen.coroutine
 	def time_disconnect(self, count):
 		count += 1
-		if count < 5:
+		if count == 1:
 			for i in self.player.get_opponents():
-				i.wait(": they have disconnected for {} seconds".format(count), self.player)
+				i.wait(": they have disconnected for {} minute".format(count), self.player)
+			self.disconnect_timer = ioloop.IOLoop.instance().call_later(60, lambda x=count: self.time_disconnect(x))
+		elif count < 5:
+			for i in self.player.get_opponents():
+				i.wait(": they have disconnected for {} minutes".format(count), self.player)
 			self.disconnect_timer = ioloop.IOLoop.instance().call_later(60, lambda x=count: self.time_disconnect(x))
 		else:
 			futures = []


### PR DESCRIPTION
+ Fix Mandarin  not placing treasures back correctly
+ Fix crossroads throne room giving incorrect actions #88 
   + removed played_actions attribute
   + renamed played -> played_cards
   + added played_inclusive to client to account for all cards played including ghost cards i.e. throne room adds two of the selected card to played_inclusive
+ fix mint issue with auto select failing
+ fix disconnect timer msg 