### PR TITLE
Update lock manual

### DIFF
--- a/cardpile.py
+++ b/cardpile.py
@@ -146,7 +146,7 @@ class HandPile():
 
 	def extract_specific(self, card):
 		if card.title in self.data:
-			extracted_card = self.data[card_title].pop(card)
+			extracted_card = self.data[card.title].pop(card)
 			if self.get_count(card.title) == 0:
 				del self.data[card.title]
 			return extracted_card

--- a/client.py
+++ b/client.py
@@ -383,7 +383,9 @@ class DmClient(Client):
 			self.update_discard_size()
 			yield gen.maybe_future(new_card.on_gain())
 			yield gen.maybe_future(self.hand.do_reactions("Gain", new_card))
-			self.update_mode()
+			for p in self.game.players:
+				if not p.is_waiting():
+					p.update_mode()
 		else:
 			self.game.announce(self.name_string() + " tries to gain " + self.game.card_from_title(card).log_string() + " but it is out of supply.")
 
@@ -397,7 +399,9 @@ class DmClient(Client):
 
 			yield gen.maybe_future(new_card.on_gain())
 			yield gen.maybe_future(self.hand.do_reactions("Gain", new_card))
-			self.update_mode()
+			for p in self.game.players:
+				if not p.is_waiting():
+					p.update_mode()
 			#if the gained card is still in discard pile, then we can remove and add to hand
 			if self.discard_pile and new_card == self.discard_pile[-1]:
 				self.hand.add(self.discard_pile.pop())

--- a/client.py
+++ b/client.py
@@ -317,7 +317,7 @@ class DmClient(Client):
 
 	#have all opponents wait on me
 	def opponents_wait(self, msg, locked=False):
-		for i in self.get_opponents(self):
+		for i in self.get_opponents():
 			#only change lock if we are locking, update_wait must be called to unlock
 			if locked:
 				i.waiter.set_lock(self, locked)

--- a/client.py
+++ b/client.py
@@ -315,14 +315,14 @@ class DmClient(Client):
 	def is_waiting(self):
 		return self.waiter.is_waiting()
 
+	#have all opponents wait on me
 	def opponents_wait(self, msg, locked=False):
-		for i in self.game.players:
-			if i.name != self.name:
-				#only change lock if we are locking, update_wait must be called to unlock
-				if locked:
-					i.waiter.set_lock(self, locked)
-				i.waiter.append_wait(self)
-				i.waiter.wait(msg)
+		for i in self.get_opponents(self):
+			#only change lock if we are locking, update_wait must be called to unlock
+			if locked:
+				i.waiter.set_lock(self, locked)
+			i.waiter.append_wait(self)
+			i.waiter.wait(msg)
 
 	def update_wait(self, manually_called=False):
 		for i in self.game.players:

--- a/client.py
+++ b/client.py
@@ -324,11 +324,11 @@ class DmClient(Client):
 			i.waiter.append_wait(self)
 			i.waiter.wait(msg)
 
+	#notify others that they should be done waiting on me
+	#if unlocking need to update mode manually
 	def update_wait(self, manually_called=False):
 		for i in self.game.players:
-			if manually_called:
-				i.waiter.set_lock(self, False)
-			i.waiter.notify(self)
+			i.waiter.notify(self, manually_called)
 
 	def discard(self, cards, pile):
 		for x in cards:
@@ -383,6 +383,7 @@ class DmClient(Client):
 			self.update_discard_size()
 			yield gen.maybe_future(new_card.on_gain())
 			yield gen.maybe_future(self.hand.do_reactions("Gain", new_card))
+			self.update_mode()
 		else:
 			self.game.announce(self.name_string() + " tries to gain " + self.game.card_from_title(card).log_string() + " but it is out of supply.")
 
@@ -396,6 +397,7 @@ class DmClient(Client):
 
 			yield gen.maybe_future(new_card.on_gain())
 			yield gen.maybe_future(self.hand.do_reactions("Gain", new_card))
+			self.update_mode()
 			#if the gained card is still in discard pile, then we can remove and add to hand
 			if self.discard_pile and new_card == self.discard_pile[-1]:
 				self.hand.add(self.discard_pile.pop())

--- a/client.py
+++ b/client.py
@@ -223,8 +223,11 @@ class DmClient(Client):
 				self.game.end_game(afk_players)
 		else:
 			self.write_json(**self.last_mode)
+		
 		turn_owner = self.game.get_turn_owner()
 		turn_owner.write_json(**turn_owner.last_mode)
+		turn_owner.write_json(command="startTurn", actions=self.actions, buys=self.buys, 
+			balance=self.balance)
 
 	def end_turn(self):
 		# cleanup before game ends

--- a/sets/card.py
+++ b/sets/card.py
@@ -135,7 +135,7 @@ class AttackCard(Card):
 		else:
 			self.played_by.wait_many("to react", reacting_players, True)
 			#fire all the reactions in parallel
-			yield reaction_futures
+			yield parallel_selects(reaction_futures, reacting_players, lambda x,y: y.update_mode())
 			self.attack()
 
 	def is_blocked(self, target):

--- a/sets/intrigue.py
+++ b/sets/intrigue.py
@@ -620,9 +620,7 @@ class Torturer(crd.AttackCard):
 			player.opponents_wait("to choose", True)
 			selection = yield player.select(1, 1, ["Discard 2 cards", "Gain a Curse"], "Choose one:")
 			if selection[0] == 'Gain a Curse':
-				player.update_wait(True)
 				yield player.gain_to_hand('Curse')
-				crd.AttackCard.get_next(self, player)
 			else:
 				discard_selection = player.hand.auto_select(2, True)
 				if discard_selection:
@@ -635,8 +633,9 @@ class Torturer(crd.AttackCard):
 					self.game.announce(player.name_string() + " discards " + str(len(discard_selection)) + " cards")
 					player.discard(discard_selection, player.discard_pile)
 					player.update_hand()
-				player.update_wait(True)
-				crd.AttackCard.get_next(self, player)
+			player.update_wait(True)
+			player.update_mode()
+			crd.AttackCard.get_next(self, player)
 
 
 class Tribute(crd.Card):

--- a/sets/prosperity.py
+++ b/sets/prosperity.py
@@ -550,7 +550,6 @@ class Vault(crd.Card):
 		                   ", gaining +$" + str(len(selection)))
 
 		self.played_by.wait_many("to discard", self.played_by.get_opponents(), True)
-		
 		#ask opponents to discard 2 to draw 1
 		opponents = self.played_by.get_opponents()
 		crd.parallel_selects(map(lambda x: x.select(1, 1, ["Yes", "No"], "Discard 2 cards to draw 1?"), 
@@ -566,10 +565,9 @@ class Vault(crd.Card):
 				drawn = player.draw(1)
 				player.update_hand()
 			self.game.announce(player.name_string() + " discards " + str(len(discard_selection)) + " cards and draws " + drawn)
-			player.update_wait(True)
-		else:
-			player.update_wait(True)
+		player.update_wait(True)
 		if not self.played_by.is_waiting():
+			self.played_by.update_mode()
 			crd.Card.on_finished(self, False, True)
 
 
@@ -804,6 +802,7 @@ class Forge(crd.Card):
 				yield self.played_by.gain(gained[0])
 				crd.Card.on_finished(self)
 			self.played_by.update_wait(True)
+			self.played_by.update_mode()
 		crd.Card.on_finished(self)
 
 # --------------------------------------------------------

--- a/sets/prosperity.py
+++ b/sets/prosperity.py
@@ -517,13 +517,13 @@ class Royal_Seal(crd.Money):
 		self.spend_all = False
 
 	@gen.coroutine
-	def on_buy_effect(self, purchased_card):
-		selection = yield self.played_by.select(1, 1, ["Yes", "No"], "Place " + purchased_card.title + " on top of deck?")
+	def on_gain_effect(self, gained_card):
+		selection = yield self.played_by.select(1, 1, ["Yes", "No"], "Place " + gained_card.title + " on top of deck?")
 		if selection[0] == "Yes":
-			purchased_card = self.played_by.search_and_extract_card(purchased_card)
+			gained_card = self.played_by.search_and_extract_card(gained_card)
 			self.game.announce(self.played_by.name_string() + " uses " + self.log_string() + " to place "
-				+ purchased_card.log_string() + " on the top of their deck")
-			self.played_by.deck.append(purchased_card)
+				+ gained_card.log_string() + " on the top of their deck")
+			self.played_by.deck.append(gained_card)
 
 class Vault(crd.Card):
 	def __init__(self, game, played_by):

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -372,6 +372,7 @@ class TestCard(tornado.testing.AsyncTestCase):
 
 		#player 2 hides secret chamber
 		yield tu.send_input(self.player2, "post_selection", ["Hide"])
+		yield gen.sleep(.1)
 		self.assertTrue(self.player1.last_mode["mode"] != "wait")
 
 	@tornado.testing.gen_test

--- a/tests/hinterlands_tests.py
+++ b/tests/hinterlands_tests.py
@@ -244,7 +244,29 @@ class TestHinterland(tornado.testing.AsyncTestCase):
 		yield tu.send_input(self.player1, "post_selection", ["Put on top of deck"])
 		self.assertTrue(self.player1.deck[-1].title == "Silver")
 
+	@tornado.testing.gen_test
+	def test_trader_royal_seal(self):
+		tu.print_test_header("test Royal Seal Trader")
+		royal_seal = prosperity.Royal_Seal(self.game, self.player1)
+		trader = hl.Trader(self.game, self.player1)
+		self.player1.hand.add(royal_seal)
+		self.player1.hand.add(trader)
 
+		royal_seal.play()
+		yield tu.send_input(self.player1, "buyCard", "Copper")
+		self.assertTrue(self.player1.last_mode["mode"] == "select")
+		yield tu.send_input(self.player1, "post_selection", ["Reveal"])
+		self.assertTrue(self.game.get_turn_owner() == self.player1)
+
+		self.assertTrue(self.player1.last_mode["mode"] == "select")
+		# trader triggers again for the new silver
+		yield tu.send_input(self.player1, "post_selection", ["Reveal"])
+		yield gen.sleep(.1)
+		# royal seal triggers
+		self.assertTrue(self.game.get_turn_owner() == self.player1)
+		self.assertTrue(self.player1.last_mode["mode"] == "select")
+		yield tu.send_input(self.player1, "post_selection", ["Yes"])
+		self.assertTrue(self.player1.deck[-1].title == "Silver")
 
 
 if __name__ == '__main__':

--- a/tests/prosperity_tests.py
+++ b/tests/prosperity_tests.py
@@ -129,6 +129,8 @@ class TestProsperity(tornado.testing.AsyncTestCase):
 		yield tu.send_input(self.player1, "post_selection", ["Reveal"])
 		self.assertTrue(self.player2.last_mode["mode"] == "wait")
 		yield tu.send_input(self.player1, "post_selection", ["Trash"])
+		yield gen.sleep(.1)
+
 		self.assertTrue(self.player2.last_mode["mode"] != "wait")
 		self.assertTrue(self.game.trash_pile[-1].title == "Curse")
 

--- a/waitHandler.py
+++ b/waitHandler.py
@@ -60,7 +60,7 @@ class WaitHandler():
 			for i in self.player.get_opponents():
 				if i not in afk_players:
 					futures.append(i.select(1,1, ["Yes"],
-						"{} {} not responded for over 5 minutes, force forefeit?".format(", ".join([i.name for i in afk_players]), "have" if len(afk_players) > 1 else "has")))	
+						"{} {} not responded for awhile, force forefeit?".format(", ".join([i.name for i in afk_players]), "have" if len(afk_players) > 1 else "has")))	
 			wait_iterator = gen.WaitIterator(*futures)
 			while not wait_iterator.done():
 				selected = yield wait_iterator.next()

--- a/waitHandler.py
+++ b/waitHandler.py
@@ -23,16 +23,22 @@ class WaitHandler():
 	def append_wait(self, to_append):
 		self.waiting_on.add(to_append.name)
 
-	def notify(self, notifier):
-		if not notifier.name in self.locked:
-			if self.is_waiting_on(notifier):
+	def notify(self, notifier, unlock=False):
+		if self.is_waiting_on(notifier):
+			if unlock or not notifier.name in self.locked:
+				self.set_lock(notifier, False)
 				self.waiting_on.remove(notifier.name)
 				notifier.waiter.remove_afk_timer()
+
 				if not self.is_waiting():
-					self.player.update_mode()
+					# i'm not waiting, restart timer
 					self.reset_afk_timer()
+					# if i was not unlocked, called automatically, update mode
+					if not unlock:
+						self.player.update_mode()
 				elif not self.is_waiting_on(self.player):
 					self.wait(self.msg)
+
 
 	def set_lock(self, locked_person, locked):
 		if locked:

--- a/waitHandler.py
+++ b/waitHandler.py
@@ -5,8 +5,8 @@ class WaitHandler():
 
 	def __init__(self, player):
 		self.player = player
-		# on = list of player names waiting for, callback called after select/gain gets response, 
-		self.waiting_on = []
+		# on = set of player names waiting for, callback called after select/gain gets response, 
+		self.waiting_on = set()
 		self.msg = ""
 		#locked = set of player names we ignore auto updates (and keep waiting) until manually removed from locked set
 		self.locked = set()
@@ -21,8 +21,7 @@ class WaitHandler():
 		self.player.write_json(command="updateMode", mode="wait", msg="Waiting for " + self.waiting_on_string() + " " + self.msg)
 
 	def append_wait(self, to_append):
-		if not self.is_waiting_on(to_append):
-			self.waiting_on.append(to_append.name)
+		self.waiting_on.add(to_append.name)
 
 	def notify(self, notifier):
 		if not notifier.name in self.locked:


### PR DESCRIPTION
Locked waits require setting a new mode after unlocking.
- add `gain_helper` for common code used in `gain`, `gain_to_hand`, `buy_card`
- fix resuming not calling startturn
- fixes #94 