### PR TITLE
fix treasury

### DIFF
--- a/sets/seaside.py
+++ b/sets/seaside.py
@@ -345,9 +345,9 @@ class Treasury(crd.Card):
 	def cleanup(self):
 		total_victories_bought = len([x for x in self.played_by.bought_cards if 'Victory' in x.type])
 		if total_victories_bought == 0:
-			total_treasuries_played = len([x for x in self.played_by.played_inclusive if x.title == self.title])
+			total_treasuries_played = len([x for x in self.played_by.played_cards if x.title == self.title])
 			if total_treasuries_played > 1:
-				selection = yield self.played_by.select(1, 1, [x for x in range(1, total_treasuries_played + 1)],
+				selection = yield self.played_by.select(1, 1, [x for x in range(0, total_treasuries_played + 1)],
 				                                        'Select the amount of treasuries you would like to return to the top of your deck')
 				amount_to_return = selection[0]
 			else:

--- a/tests/seaside_tests.py
+++ b/tests/seaside_tests.py
@@ -157,16 +157,19 @@ class TestSeaside(tornado.testing.AsyncTestCase):
 	@tornado.testing.gen_test
 	def test_Treasury(self):
 		tu.print_test_header("test Treasury")
-		treasury = sea.Treasury(self.game, self.player1)
+		treasury1 = sea.Treasury(self.game, self.player1)
+		treasury2 = sea.Treasury(self.game, self.player1)
+		self.player1.hand.add(treasury1)
+		self.player1.hand.add(treasury2)
 
-		tu.add_many_to_hand(self.player1, treasury, 2)
-
+		select_future = gen.Future()
+		self.player1.select = unittest.mock.Mock(return_value=select_future)
 		tu.send_input(self.player1, "play", "Treasury")
 		tu.send_input(self.player1, "play", "Treasury")
-		self.player1.buy_card('Copper')
 		self.player1.end_turn()
-
-		yield tu.send_input(self.player1, "post_selection", [2])
+		self.player1.select.assert_called_once_with(1, 1, [0, 1, 2], unittest.mock.ANY)
+		select_future.set_result([2])
+		yield gen.sleep(.1)
 		self.assertTrue(self.player1.hand.get_count("Treasury") == 2)
 
 	@tornado.testing.gen_test


### PR DESCRIPTION
allow returning 0 treasuries to deck
fix selection asking for extra treasuries to return when played with throne room